### PR TITLE
Fix refund authorization token in AdminOrders

### DIFF
--- a/src/pages/admin/AdminOrders.tsx
+++ b/src/pages/admin/AdminOrders.tsx
@@ -545,7 +545,7 @@ const AdminOrders = () => {
         {
           method: 'POST',
           headers: {
-            Authorization: `Bearer ${session.access_token}`,
+            Authorization: `Bearer ${session.session.access_token}`,
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({


### PR DESCRIPTION
## Summary
- correct Authorization header for refund in AdminOrders page

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run format:check`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68897f9b33a88321bb16d5fcc1f82ce8