### PR TITLE
Add privacy policy & terms pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,8 @@ import AdminPage from './pages/AdminPage';
 import MessagesPage from './pages/MessagesPage';
 import EmailConfirmationPage from './pages/EmailConfirmationPage';
 import SpectaclesPage from './pages/SpectaclesPage';
+import PrivacyPolicyPage from './pages/PrivacyPolicyPage';
+import TermsPage from './pages/TermsPage';
 import { supabase } from './lib/supabase';
 import toast from 'react-hot-toast';
 
@@ -98,6 +100,8 @@ function App() {
               <Route path="/admin" element={<AdminPage />} />
               {/* Placeholder routes */}
               <Route path="/spectacles" element={<SpectaclesPage />} />
+              <Route path="/privacy-policy" element={<PrivacyPolicyPage />} />
+              <Route path="/terms" element={<TermsPage />} />
               <Route
                 path="/machines"
                 element={

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import {
   Heart,
   ArrowUp,
@@ -171,14 +172,20 @@ const Footer = () => {
                 </a>
               </li>
               <li>
-                <a href="#" className="hover:text-blue-400 transition-colors">
+                <Link
+                  to="/privacy-policy"
+                  className="hover:text-blue-400 transition-colors"
+                >
                   Politique de Confidentialité
-                </a>
+                </Link>
               </li>
               <li>
-                <a href="#" className="hover:text-blue-400 transition-colors">
+                <Link
+                  to="/terms"
+                  className="hover:text-blue-400 transition-colors"
+                >
                   Conditions d'Utilisation
-                </a>
+                </Link>
               </li>
             </ul>
           </div>

--- a/src/pages/PrivacyPolicyPage.tsx
+++ b/src/pages/PrivacyPolicyPage.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+const PrivacyPolicyPage = () => {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-black to-gray-900 pt-24">
+      <div className="container mx-auto px-6 py-12 space-y-6 text-gray-300">
+        <h1 className="text-4xl font-bold text-white mb-4">
+          Politique de Confidentialité
+        </h1>
+        <p>
+          Votre vie privée est importante pour nous. Cette politique explique
+          comment nous collectons, utilisons et protégeons vos informations
+          lorsque vous utilisez notre site Web et nos services.
+        </p>
+        <p>
+          Les données personnelles recueillies sont utilisées uniquement pour le
+          bon fonctionnement de nos services et ne sont jamais vendues à des
+          tiers.
+        </p>
+        <p>
+          Conformément à la réglementation en vigueur, vous disposez d&apos;un
+          droit d&apos;accès, de rectification et de suppression de vos données.
+          Pour toute demande, contactez-nous via la page&nbsp;Contact.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default PrivacyPolicyPage;

--- a/src/pages/TermsPage.tsx
+++ b/src/pages/TermsPage.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+const TermsPage = () => {
+  return (
+    <div className="min-h-screen bg-gradient-to-b from-black to-gray-900 pt-24">
+      <div className="container mx-auto px-6 py-12 space-y-6 text-gray-300">
+        <h1 className="text-4xl font-bold text-white mb-4">
+          Conditions d&apos;Utilisation
+        </h1>
+        <p>
+          En accédant à ce site, vous acceptez de respecter nos conditions
+          d&apos;utilisation. Nous nous réservons le droit de modifier ces
+          conditions à tout moment.
+        </p>
+        <p>
+          Tout contenu présent sur ce site est la propriété d&apos;OMEGA. Il est
+          interdit de le reproduire sans autorisation préalable.
+        </p>
+        <p>
+          Pour toute question concernant ces conditions, veuillez nous contacter
+          directement.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default TermsPage;


### PR DESCRIPTION
## Summary
- create PrivacyPolicy and Terms pages
- add routes for privacy policy and terms
- link to new pages from footer

## Testing
- `npm run lint` *(fails: irregular whitespace, unused vars)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6889f17bc4e083219b8462af389ebb50