### PR TITLE
Add AdminPlanningEditor module

### DIFF
--- a/src/pages/AdminPage.tsx
+++ b/src/pages/AdminPage.tsx
@@ -6,12 +6,14 @@ import {
   Package,
   MessageSquare,
   ShoppingCart,
+  Calendar,
   Settings,
 } from 'lucide-react';
 import AdminDashboard from './admin/AdminDashboard';
 import AdminUsers from './admin/AdminUsers';
 import AdminProducts from './admin/AdminProducts';
 import AdminOrders from './admin/AdminOrders';
+import AdminPlanningEditor from './admin/AdminPlanningEditor';
 import AdminMessages from './admin/AdminMessages';
 import AdminBilling from './admin/AdminBilling';
 
@@ -60,6 +62,7 @@ const AdminPage = () => {
     { id: 'users', label: 'Utilisateurs', icon: Users },
     { id: 'products', label: 'Produits', icon: Package },
     { id: 'orders', label: 'Commandes', icon: ShoppingCart },
+    { id: 'planning', label: 'Planning', icon: Calendar },
     { id: 'messages', label: 'Messages', icon: MessageSquare },
     { id: 'billing', label: 'Facturation', icon: Settings },
     { id: 'settings', label: 'Paramètres', icon: Settings },
@@ -73,6 +76,8 @@ const AdminPage = () => {
         return <AdminProducts />;
       case 'orders':
         return <AdminOrders />;
+      case 'planning':
+        return <AdminPlanningEditor />;
       case 'messages':
         return <AdminMessages />;
       case 'billing':

--- a/src/pages/admin/AdminPlanningEditor.tsx
+++ b/src/pages/admin/AdminPlanningEditor.tsx
@@ -1,0 +1,182 @@
+import React, { useState } from 'react';
+import { Calendar, Plus, Download } from 'lucide-react';
+import { exportElementAsPDF } from '../../utils/pdfGenerator';
+
+interface EventItem {
+  id: string;
+  date: string;
+  location: string;
+  color: string;
+  providers: string[];
+}
+
+const defaultProviders = ['Prestataire 1', 'Prestataire 2', 'Prestataire 3'];
+
+const AdminPlanningEditor: React.FC = () => {
+  const [events, setEvents] = useState<EventItem[]>([]);
+  const [providers] = useState<string[]>(defaultProviders);
+  const [form, setForm] = useState({
+    date: '',
+    location: '',
+    color: '#ff0000',
+    providers: [] as string[],
+  });
+
+  const toggleProvider = (name: string) => {
+    setForm(prev => ({
+      ...prev,
+      providers: prev.providers.includes(name)
+        ? prev.providers.filter(p => p !== name)
+        : [...prev.providers, name],
+    }));
+  };
+
+  const addEvent = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!form.date || !form.location) return;
+    const newEvent: EventItem = {
+      id: Date.now().toString(),
+      date: form.date,
+      location: form.location,
+      color: form.color,
+      providers: form.providers,
+    };
+    setEvents(prev => [...prev, newEvent]);
+    setForm({ date: '', location: '', color: '#ff0000', providers: [] });
+  };
+
+  const exportGeneralPDF = () => exportElementAsPDF('planning-table', 'planning-general');
+
+  const exportProviderPDF = (provider: string) =>
+    exportElementAsPDF(`planning-${provider}`, `planning-${provider}`);
+
+  return (
+    <div className="text-white space-y-8">
+      <h2 className="text-2xl font-bold flex items-center gap-2">
+        <Calendar /> Planning Événementiel
+      </h2>
+
+      <form
+        onSubmit={addEvent}
+        className="bg-white/5 p-4 rounded-lg space-y-4"
+      >
+        <div className="grid md:grid-cols-4 gap-4">
+          <input
+            type="date"
+            value={form.date}
+            onChange={e => setForm({ ...form, date: e.target.value })}
+            className="bg-gray-800 rounded p-2"
+            required
+          />
+          <input
+            type="text"
+            placeholder="Lieu"
+            value={form.location}
+            onChange={e => setForm({ ...form, location: e.target.value })}
+            className="bg-gray-800 rounded p-2"
+            required
+          />
+          <input
+            type="color"
+            value={form.color}
+            onChange={e => setForm({ ...form, color: e.target.value })}
+            className="w-16 h-10 p-1"
+          />
+          <div className="flex items-center gap-2">
+            {providers.map(p => (
+              <label key={p} className="flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  checked={form.providers.includes(p)}
+                  onChange={() => toggleProvider(p)}
+                />
+                <span className="text-sm">{p}</span>
+              </label>
+            ))}
+          </div>
+        </div>
+        <button
+          type="submit"
+          className="flex items-center gap-2 bg-yellow-500 text-black px-4 py-2 rounded font-semibold"
+        >
+          <Plus size={16} /> Ajouter
+        </button>
+      </form>
+
+      {events.length > 0 && (
+        <div className="space-y-6">
+          <div className="flex justify-between items-center">
+            <h3 className="text-xl font-semibold">Planning Général</h3>
+            <button
+              onClick={exportGeneralPDF}
+              className="flex items-center gap-2 text-sm bg-yellow-500 text-black px-3 py-1 rounded"
+            >
+              <Download size={16} /> Export PDF
+            </button>
+          </div>
+          <table
+            id="planning-table"
+            className="w-full text-left border-collapse"
+          >
+            <thead>
+              <tr className="bg-white/10">
+                <th className="p-2">Date</th>
+                <th className="p-2">Lieu</th>
+                <th className="p-2">Prestataires</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map(ev => (
+                <tr key={ev.id} style={{ backgroundColor: ev.color }}>
+                  <td className="p-2">{ev.date}</td>
+                  <td className="p-2">{ev.location}</td>
+                  <td className="p-2">{ev.providers.join(', ')}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {providers.map(provider => {
+        const providerEvents = events.filter(e => e.providers.includes(provider));
+        if (providerEvents.length === 0) return null;
+        return (
+          <div key={provider} className="space-y-2">
+            <div className="flex justify-between items-center mt-8">
+              <h3 className="text-xl font-semibold">Planning {provider}</h3>
+              <button
+                onClick={() => exportProviderPDF(provider)}
+                className="flex items-center gap-2 text-sm bg-yellow-500 text-black px-3 py-1 rounded"
+              >
+                <Download size={16} /> Export PDF
+              </button>
+            </div>
+            <table
+              id={`planning-${provider}`}
+              className="w-full text-left border-collapse"
+            >
+              <thead>
+                <tr className="bg-white/10">
+                  <th className="p-2">Date</th>
+                  <th className="p-2">Lieu</th>
+                </tr>
+              </thead>
+              <tbody>
+                {providerEvents.map(ev => (
+                  <tr key={ev.id} style={{ backgroundColor: ev.color }}>
+                    <td className="p-2">{ev.date}</td>
+                    <td className="p-2">{ev.location}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default AdminPlanningEditor;
+

--- a/src/utils/__tests__/pdfGenerator.test.ts
+++ b/src/utils/__tests__/pdfGenerator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { generateInvoicePDF, printInvoice } from '../pdfGenerator';
+import { generateInvoicePDF, printInvoice, exportElementAsPDF } from '../pdfGenerator';
 
 // Mock jsPDF and html2canvas for tests where they would be called
 vi.mock('jspdf', () => ({
@@ -23,5 +23,11 @@ describe('pdfGenerator utilities', () => {
 
   it('printInvoice throws when element missing', () => {
     expect(() => printInvoice()).toThrow('Élément de la facture non trouvé');
+  });
+
+  it('exportElementAsPDF throws when element missing', async () => {
+    await expect(exportElementAsPDF('missing', 'test')).rejects.toThrow(
+      'Élément non trouvé'
+    );
   });
 });

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -119,3 +119,23 @@ export const printInvoice = () => {
   document.body.innerHTML = originalContents;
   window.location.reload();
 };
+
+/**
+ * Export any HTML element as a PDF file.
+ * @param elementId - DOM element id.
+ * @param fileName - Name of the resulting PDF file.
+ */
+export const exportElementAsPDF = async (elementId: string, fileName: string) => {
+  const element = document.getElementById(elementId);
+  if (!element) {
+    throw new Error(`Élément non trouvé (id="${elementId}")`);
+  }
+  const canvas = await html2canvas(element, { scale: 2, useCORS: true });
+  const imgData = canvas.toDataURL('image/png');
+  const pdf = new jsPDF('p', 'mm', 'a4');
+  const pdfWidth = pdf.internal.pageSize.getWidth();
+  const imgHeight = (canvas.height * pdfWidth) / canvas.width;
+  pdf.addImage(imgData, 'PNG', 0, 0, pdfWidth, imgHeight);
+  pdf.save(`${fileName}.pdf`);
+  return true;
+};


### PR DESCRIPTION
## Summary
- introduce AdminPlanningEditor for event scheduling with PDF export
- add exportElementAsPDF utility
- update tests for pdf generator
- add planning tab to admin interface

## Testing
- `npx eslint src/pages/admin/AdminPlanningEditor.tsx src/utils/pdfGenerator.ts src/pages/AdminPage.tsx src/utils/__tests__/pdfGenerator.test.ts`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688b2fb0c4848321ab38bbcd27f48a57