### PR TITLE
Fix multi-date event creation

### DIFF
--- a/src/pages/admin/AdminPlanningEditor.tsx
+++ b/src/pages/admin/AdminPlanningEditor.tsx
@@ -330,7 +330,7 @@ const AdminPlanningEditor: React.FC = () => {
             });
           if (error) throw error;
         }
-        toast.success('Événement ajouté');
+        toast.success(targetDates.length > 1 ? 'Événements ajoutés' : 'Événement ajouté');
       }
       
       resetEventForm();
@@ -406,14 +406,16 @@ const AdminPlanningEditor: React.FC = () => {
     setShowEventModal(true);
   };
 
-  const openEventModal = (date?: Date) => {
-    const baseDate = date || selectedDates[0] || currentDate;
+  const openEventModal = () => {
+    const baseDate = selectedDates[0] || currentDate;
     setEventForm({
       event_date: baseDate.toISOString().slice(0, 10),
       location_id: locations[0]?.id || '',
       provider_ids: [],
     });
-    setSelectedDates([baseDate]);
+    if (selectedDates.length === 0) {
+      setSelectedDates([baseDate]);
+    }
     setShowEventModal(true);
   };
 
@@ -781,7 +783,9 @@ const AdminPlanningEditor: React.FC = () => {
                 </h4>
                 {selectedDates.length > 1 && (
                   <div className="text-blue-400 text-sm mb-2">
-                    {selectedDates.length} dates sélectionnées
+                    {selectedDates
+                      .map(d => d.toLocaleDateString('fr-FR'))
+                      .join(', ')}
                   </div>
                 )}
                 
@@ -1071,7 +1075,11 @@ const AdminPlanningEditor: React.FC = () => {
                   className="flex-1 bg-gradient-to-r from-blue-500 to-blue-600 text-white py-3 rounded-lg font-semibold hover:shadow-lg hover:shadow-blue-500/25 transition-all duration-300 flex items-center justify-center gap-2"
                 >
                   <Save size={16} />
-                  {editingEvent ? 'Mettre à jour' : 'Créer l\'événement'}
+                  {editingEvent
+                    ? 'Mettre à jour'
+                    : selectedDates.length > 1
+                      ? 'Créer les événements'
+                      : 'Créer l\'événement'}
                 </button>
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- preserve selected dates when opening event creation modal
- display selected date list in sidebar
- insert multiple events at once and adjust success messages
- update button label when creating multiple events

## Testing
- `npm test --silent`
- `npm run lint --silent` *(fails: Irregular whitespace, no-unused-vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688c0a5addb483218fbf067d3c136976