### PR TITLE
Improve invoice refund data

### DIFF
--- a/src/components/InvoicePDF.tsx
+++ b/src/components/InvoicePDF.tsx
@@ -22,9 +22,9 @@ const InvoicePDF: React.FC<InvoicePDFProps> = ({
     const actualAmountPaid = (invoice.payment_records || [])
       .filter(payment => payment.payment_method !== 'refund')
       .reduce((sum, payment) => sum + payment.amount, 0);
-    const totalRefunded = (invoice.payment_records || [])
-      .filter(payment => payment.payment_method === 'refund')
-      .reduce((sum, payment) => sum + Math.abs(payment.amount), 0);
+    const totalRefunded = (invoice.refunds || [])
+      .filter(refund => refund.status === 'succeeded')
+      .reduce((sum, refund) => sum + refund.amount, 0);
     const netToPay = Math.max(
       0,
       invoice.total_ttc - actualAmountPaid + totalRefunded

--- a/src/types/billing.ts
+++ b/src/types/billing.ts
@@ -80,7 +80,7 @@ export interface Invoice {
   customer_phone?: string;
   customer_address?: any;
   billing_address?: any;
-  status: 'draft' | 'sent' | 'paid' | 'overdue' | 'cancelled';
+  status: 'draft' | 'sent' | 'paid' | 'overdue' | 'cancelled' | 'refunded';
   subtotal_ht: number;
   tax_amount: number;
   total_ttc: number;
@@ -96,6 +96,7 @@ export interface Invoice {
   paid_at?: string;
   invoice_items?: InvoiceItem[];
   payment_records?: PaymentRecord[];
+  refunds?: Refund[];
   customer?: {
     first_name: string;
     last_name: string;
@@ -125,7 +126,13 @@ export interface PaymentRecord {
   invoice_id: string;
   amount: number;
   payment_date: string;
-  payment_method: 'virement' | 'cheque' | 'especes' | 'carte' | 'prelevement';
+  payment_method:
+    | 'virement'
+    | 'cheque'
+    | 'especes'
+    | 'carte'
+    | 'prelevement'
+    | 'refund';
   reference?: string;
   notes?: string;
   stripe_charge_id?: string;


### PR DESCRIPTION
## Summary
- extend billing types with refunds field and include refund payment method
- fetch associated refunds when loading invoices
- compute payment summary including refunds in AdminBilling list
- adjust refund logic to rely on invoice refunds
- display net to pay and refunded amount in invoice PDF and list

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_688cf88498e08321b28f48e8580b9e67