### PR TITLE
Fix vertical offset in PDF export

### DIFF
--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -161,12 +161,11 @@ export const exportElementAsPDF = async (elementId: string, fileName: string = '
     imgWidth = imgHeight * canvasAspectRatio;
   }
 
-  // Centrage de l'image sur la page
+  // Centrage horizontal de l'image. Alignement en haut pour éviter un décalage vertical.
   const xOffset = (pageWidth - imgWidth) / 2;
-  const yOffset = (pageHeight - imgHeight) / 2;
 
-  // Ajout de l'image unique, redimensionnée et centrée, sans pagination
-  pdf.addImage(imgData, 'PNG', xOffset, yOffset, imgWidth, imgHeight);
+  // Ajout de l'image unique, redimensionnée et alignée en haut, sans pagination
+  pdf.addImage(imgData, 'PNG', xOffset, 0, imgWidth, imgHeight);
 
   pdf.save(`${fileName}.pdf`);
   return true;


### PR DESCRIPTION
## Summary
- avoid vertical offset when exporting planning to PDF

## Testing
- `npm test`
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' and 'no-explicit-any')*

------
https://chatgpt.com/codex/tasks/task_e_688e1f6cc52083218fff49b0f5178d85