### PR TITLE
fix: align text correctly in planning PDF

### DIFF
--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -130,14 +130,20 @@ export const exportElementAsPDF = async (elementId: string, fileName: string = '
   if (!element) {
     throw new Error(`Élément non trouvé (id="${elementId}")`);
   }
- 
+
+  // S'assure que les polices sont chargées pour éviter les décalages dans le canvas
+  if (document.fonts && document.fonts.ready) {
+    await document.fonts.ready;
+  }
+
   // Capture de l'élément en canvas avec une haute résolution et un fond noir
-  const canvas = await html2canvas(element, { 
-    scale: 2, 
+  const canvas = await html2canvas(element, {
+    scale: 2,
     useCORS: true,
     backgroundColor: '#111827', // Fond du thème sombre
     logging: false,
     allowTaint: true,
+    letterRendering: true,
   });
  
   const imgData = canvas.toDataURL('image/png');


### PR DESCRIPTION
## Summary
- ensure fonts are loaded before exporting calendar to PDF
- render letters individually to fix vertical text shift

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688e22d987848321b24d0800c625bf21