### PR TITLE
Add font offset to planning PDF export

### DIFF
--- a/src/pages/admin/AdminPlanningEditor.tsx
+++ b/src/pages/admin/AdminPlanningEditor.tsx
@@ -12,17 +12,17 @@ import {
   MapPin,
   Save,
   User,
-  Palette,
   X,
   Layers,
   Loader2,
   BarChart2,
   Tag,
-  Euro,
 } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
 import { exportElementAsPDF } from '../../utils/pdfGenerator';
 import toast from 'react-hot-toast';
+
+const PDF_FONT_OFFSET_MM = 2;
 
 // --- Interfaces de types ---
 interface Provider {
@@ -150,7 +150,7 @@ const AdminPlanningEditor: React.FC = () => {
   const handleEventClick = (clickInfo: any) => { setMultiSelectedDates([]); const event = events.find(e => e.id === clickInfo.event.id); if (event) { setEditingEvent(event); setEventForm({ location_id: event.location_id, provider_ids: event.provider_ids }); setShowEventModal(true); } };
   const handleEventDrop = async (info: any) => { const { event, oldEvent } = info; const newDate = toYYYYMMDD(event.start); const eventId = event.id; setEvents(currentEvents => currentEvents.map(e => e.id === eventId ? { ...e, event_date: newDate } : e)); const { error } = await supabase.from('planning_events').update({ event_date: newDate }).eq('id', eventId); if (error) { toast.error("Le déplacement a échoué."); setEvents(currentEvents => currentEvents.map(e => e.id === eventId ? { ...e, event_date: toYYYYMMDD(oldEvent.start) } : e)); info.revert(); } };
   
-  const handleExportPDF = async () => { if (isExporting) return; setIsExporting(true); const toastId = toast.loading('Génération du PDF...'); try { await exportElementAsPDF('planning-export', `planning-${toYYYYMMDD(new Date())}`); toast.success('PDF généré !', { id: toastId }); } catch (error) { console.error(error); toast.error('Échec du PDF.', { id: toastId }); } finally { setIsExporting(false); } };
+  const handleExportPDF = async () => { if (isExporting) return; setIsExporting(true); const toastId = toast.loading('Génération du PDF...'); try { await exportElementAsPDF('planning-export', `planning-${toYYYYMMDD(new Date())}`, PDF_FONT_OFFSET_MM); toast.success('PDF généré !', { id: toastId }); } catch (error) { console.error(error); toast.error('Échec du PDF.', { id: toastId }); } finally { setIsExporting(false); } };
 
   const filteredEvents = useMemo(() => events.filter(event => (selectedProvider === 'all' || event.provider_ids.includes(selectedProvider)) && (selectedLocation === 'all' || event.location_id === selectedLocation) && (selectedEventType === 'all' || event.location?.event_type_id === selectedEventType)), [events, selectedProvider, selectedLocation, selectedEventType]);
   

--- a/src/utils/pdfGenerator.ts
+++ b/src/utils/pdfGenerator.ts
@@ -124,8 +124,13 @@ export const printInvoice = () => {
  * Exporte un élément HTML en PDF sur une seule page A4.
  * @param elementId - L'ID de l'élément DOM à exporter.
  * @param fileName - Le nom du fichier PDF de sortie.
+ * @param fontOffset - Décalage vertical en millimètres pour corriger le rendu des polices.
  */
-export const exportElementAsPDF = async (elementId: string, fileName: string = 'export') => {
+export const exportElementAsPDF = async (
+  elementId: string,
+  fileName: string = 'export',
+  fontOffset: number = 0
+) => {
   const element = document.getElementById(elementId);
   if (!element) {
     throw new Error(`Élément non trouvé (id="${elementId}")`);
@@ -172,8 +177,8 @@ export const exportElementAsPDF = async (elementId: string, fileName: string = '
   // Centrage horizontal de l'image. Alignement en haut pour éviter un décalage vertical.
   const xOffset = (pageWidth - imgWidth) / 2;
 
-  // Ajout de l'image unique, redimensionnée et alignée en haut, sans pagination
-  pdf.addImage(imgData, 'PNG', xOffset, 0, imgWidth, imgHeight);
+  // Ajout de l'image unique, redimensionnée avec un décalage optionnel pour les polices
+  pdf.addImage(imgData, 'PNG', xOffset, fontOffset, imgWidth, imgHeight);
 
   pdf.save(`${fileName}.pdf`);
   return true;


### PR DESCRIPTION
## Summary
- allow pdf generation to accept a font offset to adjust vertical text positioning
- apply a 2mm font offset when exporting planning to PDF

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any & other existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688e292ebc9c8321b4d53adc63cb9426