### PR TITLE
feat: redesign homepage with modern sections

### DIFF
--- a/src/components/CTASection.tsx
+++ b/src/components/CTASection.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const CTASection = () => {
+  return (
+    <section className="py-20 bg-gradient-to-r from-yellow-400 to-orange-500 text-black text-center">
+      <div className="container mx-auto px-6">
+        <h2 className="text-3xl md:text-4xl font-bold mb-4">
+          Prêt à concrétiser votre projet ?
+        </h2>
+        <p className="mb-8 max-w-2xl mx-auto text-lg">
+          Contactez notre équipe pour obtenir un devis personnalisé et découvrez
+          comment OMEGA peut sublimer votre événement.
+        </p>
+        <Link
+          to="/contact"
+          className="inline-block px-8 py-4 rounded-full bg-black text-white font-semibold hover:bg-gray-900 transition-colors"
+        >
+          Nous contacter
+        </Link>
+      </div>
+    </section>
+  );
+};
+
+export default CTASection;

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,77 +1,45 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
-import { ChevronDown, Star, Sparkles, ArrowRight } from 'lucide-react';
 
 const Hero = () => {
-  const [mousePosition, setMousePosition] = useState({ x: 0, y: 0 });
-
-  useEffect(() => {
-    const handleMouseMove = (e: MouseEvent) => {
-      setMousePosition({ x: e.clientX, y: e.clientY });
-    };
-    window.addEventListener('mousemove', handleMouseMove);
-    return () => window.removeEventListener('mousemove', handleMouseMove);
-  }, []);
-
   return (
     <section
       id="home"
-      className="min-h-screen relative overflow-hidden bg-gradient-to-br from-black via-gray-900 to-black flex items-center"
+      className="relative flex items-center justify-center min-h-[80vh] md:min-h-screen bg-gradient-to-br from-gray-900 via-black to-gray-900"
     >
-      {/* Animated Background */}
-      <div className="absolute inset-0">
-        <div
-          className={`absolute inset-0 bg-[url('data:image/svg+xml,%3Csvg width="60" height="60" viewBox="0 0 60 60" xmlns="http://www.w3.org/2000/svg"%3E%3Cg fill="none" fill-rule="evenodd"%3E%3Cg fill="%23ffffff" fill-opacity="0.05"%3E%3Ccircle cx="7" cy="7" r="1"/%3E%3C/g%3E%3C/g%3E%3C/svg%3E')] opacity-30`}
-        ></div>
-        <div
-          className="absolute w-96 h-96 bg-gradient-to-r from-blue-500/20 to-purple-600/20 rounded-full blur-3xl transition-all duration-1000"
-          style={{
-            left: mousePosition.x - 192,
-            top: mousePosition.y - 192,
-          }}
-        ></div>
+      {/* Background decoration */}
+      <div className="absolute inset-0 overflow-hidden">
+        <div className="absolute inset-0 opacity-20 bg-[radial-gradient(circle_at_center,rgba(255,255,255,0.2),transparent_70%)]"></div>
       </div>
 
-      <div className="container mx-auto px-6 relative z-10">
-        <div className="max-w-4xl mx-auto text-center">
-          <div className="flex justify-center mb-6"></div>
+      <div className="relative z-10 text-center px-6 max-w-3xl">
+        <img
+          src="/Logo-omega-hq-transparent.png"
+          alt="OMEGA"
+          className="mx-auto h-24 md:h-32 mb-8"
+        />
+        <h1 className="text-4xl md:text-6xl font-extrabold text-white mb-6 leading-tight">
+          Solutions événementielles haut de gamme
+        </h1>
+        <p className="text-lg md:text-xl text-gray-300 mb-10">
+          Machines à fumée professionnelles, spectacles sur‑mesure et expertise
+          technique depuis 1996.
+        </p>
 
-          <h1 className="text-6xl md:text-8xl font-bold mb-6 bg-gradient-to-r from-white via-yellow-400 to-orange-500 bg-clip-text text-transparent leading-tight">
-            <img
-              src="/Logo-omega-hq-transparent.png"
-              alt="OMEGA"
-              className="h-20 mx-auto mb-4"
-            />
-          </h1>
-
-          <p className="text-2xl text-gray-300 mb-2 font-semibold">
-            Depuis 1996
-          </p>
-          <p className="text-lg text-gray-400 mb-12 max-w-2xl mx-auto leading-relaxed">
-            Fabricant français de machines à fumée professionnelles et
-            spécialiste des spectacles événementiels
-          </p>
-
-          <div className="flex flex-col sm:flex-row gap-6 justify-center items-center mb-16">
-            <Link
-              to="/machine-hazer"
-              className="bg-gradient-to-r from-blue-500 to-purple-600 text-white px-8 py-4 rounded-full text-lg font-semibold hover:shadow-2xl hover:shadow-blue-500/25 transform hover:-translate-y-1 transition-all duration-300 flex items-center gap-2"
-            >
-              Découvrir nos Machines
-              <ArrowRight size={20} />
-            </Link>
-            <Link
-              to="/spectacles"
-              className="border-2 border-blue-400/50 text-white px-8 py-4 rounded-full text-lg font-semibold hover:bg-blue-500/10 hover:border-blue-400 transition-all duration-300"
-            >
-              Nos Spectacles
-            </Link>
-          </div>
+        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <Link
+            to="/machine-hazer"
+            className="px-8 py-4 rounded-full bg-yellow-400 text-black font-semibold hover:bg-yellow-300 transition-colors"
+          >
+            Nos Machines
+          </Link>
+          <Link
+            to="/spectacles"
+            className="px-8 py-4 rounded-full border border-white text-white font-semibold hover:bg-white hover:text-black transition-colors"
+          >
+            Nos Spectacles
+          </Link>
         </div>
-      </div>
-
-      <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 animate-bounce">
-        <ChevronDown className="text-white/60" size={32} />
       </div>
     </section>
   );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import Hero from '../components/Hero';
-import HazerSection from '../components/HazerSection';
-import ElFuegoSection from '../components/ElFuegoSection';
+import Services from '../components/Services';
 import About from '../components/About';
+import CTASection from '../components/CTASection';
 import Contact from '../components/Contact';
 
 const HomePage = () => {
   return (
     <div className="min-h-screen">
       <Hero />
-      <HazerSection />
-      <ElFuegoSection />
+      <Services />
       <About />
+      <CTASection />
       <Contact />
     </div>
   );


### PR DESCRIPTION
## Summary
- Refonte du Hero avec un fond dégradé et des appels à l'action clairs
- Ajout d'une section CTA dédiée
- Réorganisation de HomePage autour de nouvelles sections professionnelles

## Testing
- `npx eslint src/components/Hero.tsx src/components/CTASection.tsx src/pages/HomePage.tsx`
- `npm run lint` (échec : erreurs existantes dans le dépôt)
- `npm test` (échec : pdfGenerator.test.ts ne trouve pas l'élément `invoice-pdf`)


------
https://chatgpt.com/codex/tasks/task_e_6895e2d62cb88321a9feab11e19b03f2