### PR TITLE
Corriger l'alignement du planning PDF

### DIFF
--- a/src/pages/admin/AdminPlanningEditor.tsx
+++ b/src/pages/admin/AdminPlanningEditor.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react'
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
+import html2canvas from 'html2canvas';
+import jsPDF from 'jspdf';
 import {
   Calendar as CalendarIcon,
   Plus,
@@ -21,7 +23,6 @@ import {
   Euro,
 } from 'lucide-react';
 import { supabase } from '../../lib/supabase';
-import { exportElementAsPDF } from '../../utils/pdfGenerator';
 import toast from 'react-hot-toast';
 
 // --- Interfaces de types ---
@@ -150,7 +151,7 @@ const AdminPlanningEditor: React.FC = () => {
   const handleEventClick = (clickInfo: any) => { setMultiSelectedDates([]); const event = events.find(e => e.id === clickInfo.event.id); if (event) { setEditingEvent(event); setEventForm({ location_id: event.location_id, provider_ids: event.provider_ids }); setShowEventModal(true); } };
   const handleEventDrop = async (info: any) => { const { event, oldEvent } = info; const newDate = toYYYYMMDD(event.start); const eventId = event.id; setEvents(currentEvents => currentEvents.map(e => e.id === eventId ? { ...e, event_date: newDate } : e)); const { error } = await supabase.from('planning_events').update({ event_date: newDate }).eq('id', eventId); if (error) { toast.error("Le déplacement a échoué."); setEvents(currentEvents => currentEvents.map(e => e.id === eventId ? { ...e, event_date: toYYYYMMDD(oldEvent.start) } : e)); info.revert(); } };
   
-  const handleExportPDF = async () => { if (isExporting) return; setIsExporting(true); const toastId = toast.loading('Génération du PDF...'); try { await exportElementAsPDF('planning-export', `planning-${toYYYYMMDD(new Date())}`); toast.success('PDF généré !', { id: toastId }); } catch (error) { console.error(error); toast.error('Échec du PDF.', { id: toastId }); } finally { setIsExporting(false); } };
+  const handleExportPDF = async () => { if (isExporting) return; setIsExporting(true); const toastId = toast.loading('Génération du PDF...'); try { await exportPlanningScreenshot(`planning-${toYYYYMMDD(new Date())}`); toast.success('PDF généré !', { id: toastId }); } catch (error) { console.error(error); toast.error('Échec du PDF.', { id: toastId }); } finally { setIsExporting(false); } };
 
   const filteredEvents = useMemo(() => events.filter(event => (selectedProvider === 'all' || event.provider_ids.includes(selectedProvider)) && (selectedLocation === 'all' || event.location_id === selectedLocation) && (selectedEventType === 'all' || event.location?.event_type_id === selectedEventType)), [events, selectedProvider, selectedLocation, selectedEventType]);
   


### PR DESCRIPTION
Switches PDF export to targeted calendar screenshot to fix alignment and rendering issues.

The previous generic element capture (`planning-export`) caused misalignments and rendering glitches (due to CSS transforms, line-height, etc.). The new approach targets the FullCalendar element directly with options that normalize rendering, ensuring correct alignment of text and frames in the PDF.

---
<a href="https://cursor.com/background-agent?bcId=bc-99309098-24d3-4fb5-8ff6-8da5fdd85960">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99309098-24d3-4fb5-8ff6-8da5fdd85960">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

